### PR TITLE
Make HTML's html-dfn.js work, part 2

### DIFF
--- a/lib/models/file.js
+++ b/lib/models/file.js
@@ -9,6 +9,10 @@ const NoSpecDiff = SpecDiff.NoSpecDiff;
 const AddedFileSpecDiff = SpecDiff.AddedFileSpecDiff;
 const RemovedFileSpecDiff = SpecDiff.RemovedFileSpecDiff;
 
+// Rewrite html-dfn.js path (again) so it works for diff pages.
+const rewriteHtmlDfn = html =>
+    html.replace(/src="html-dfn\.js"/g, 'src="../html-dfn.js"');
+
 
 class File {
     constructor(pr, filename) {
@@ -56,10 +60,14 @@ class WattsiFile extends File {
         return this._head = this._head ||
             WattsiHead.fromPR(this.pr, this._wattsi.headPath(this.filename), this.filename);
     }
-    
+
     get merge_base() {
         return this._merge_base = this._merge_base ||
             WattsiMergeBase.fromPR(this.pr, this._wattsi.mergeBasePath(this.filename), this.filename);
+    }
+
+    get diff() {
+        return this._diff = this._diff || new SpecDiff(this.head, this.merge_base, this.filename, rewriteHtmlDfn);
     }
 }
 
@@ -76,18 +84,18 @@ class UnchangedWattsiFile extends WattsiFile {
 
 class AddedWattsiFile extends WattsiFile {
     get diff() {
-        return this._diff = this._diff || new AddedFileSpecDiff(this.head, this.merge_base, this.filename);
+        return this._diff = this._diff || new AddedFileSpecDiff(this.head, this.merge_base, this.filename, rewriteHtmlDfn);
     }
 
     async cache() {
         await this.head.cache();
         await this.diff.cache();
-    } 
+    }
 }
 
 class RemovedWattsiFile extends WattsiFile {
     get diff() {
-        return this._diff = this._diff || new RemovedFileSpecDiff(this.head, this.merge_base, this.filename);
+        return this._diff = this._diff || new RemovedFileSpecDiff(this.head, this.merge_base, this.filename, rewriteHtmlDfn);
     }
 
     async cache() {

--- a/lib/models/spec-diff.js
+++ b/lib/models/spec-diff.js
@@ -10,13 +10,14 @@ const fetchUrl = require("../fetch-url");
 const fs = require("fs");
 
 class SpecDiff extends mix().with(ImmutableCache) {
-    constructor(head, base, filename) {
+    constructor(head, base, filename, transform) {
         super();
         this.head = head;
         this.base = base;
         this.filename = filename;
+        this.transform = transform;
     }
-    
+
     get in_same_repo() {
         return this.head.owner == this.base.owner;
     }
@@ -38,21 +39,22 @@ class SpecDiff extends mix().with(ImmutableCache) {
             return `${ b.owner }/${ b.repo }/${ number }/${ b.short_sha }...${ prefix }${ h.short_sha }${ suffix }`;
         }
     }
-  
+
     getHtmlDiffUrl() {
         let base = urlencode(this.base.cache_url);
         let head = urlencode(this.head.cache_url);
         return `https://services.w3.org/htmldiff?doc1=${ base }&doc2=${ head }`;
     }
-    
+
     get aws_s3_bucket() {
         return this.head.aws_s3_bucket;
     }
-    
+
     fetch() {
         let url = this.getHtmlDiffUrl()
         console.log(`Fetch: ${ url }`);
-        return fetchUrl(url, HTMLDIFF_SERVICE);
+        let promise = fetchUrl(url, HTMLDIFF_SERVICE);
+        return this.transform ? promise.then(this.transform) : promise;
     }
 }
 

--- a/lib/wattsi-client.js
+++ b/lib/wattsi-client.js
@@ -229,18 +229,20 @@ class WattsiClient {
             .then(_ => this.getUnchangedFilenames());
     }
 
-    // Rewrite `src="/html-dfn.js"` to `src="html-dfn.js"` in each multipage HTML file.
-    // The page is served from e.g. https://whatpr.org/html/<PR>/canvas.html, where the
-    // root-relative form resolves to whatpr.org/html-dfn.js (404). The sibling form
-    // resolves to the per-PR copy uploaded next to the page.
+    // Rewrite `src=/html-dfn.js` to a relative path so it works on PR Preview and drop link-fixup.js.
     async rewriteMultipageFiles() {
         const fsp = fs.promises;
-        for (const dir of [this.headDirPath, this.mergeBaseDirPath]) {
+        const targets = [
+            [this.headDirPath, "html-dfn.js"],
+            [this.mergeBaseDirPath, "../html-dfn.js"],
+        ];
+        for (const [dir, dfnSrc] of targets) {
             const files = await fsp.readdir(dir);
             await Promise.all(files.filter(f => f.endsWith(".html")).map(async f => {
                 const fullPath = path.join(dir, f);
                 let content = await fsp.readFile(fullPath, "utf8");
-                content = content.replace(/src=(["'])\/html-dfn\.js\1/g, 'src=$1html-dfn.js$1');
+                content = content.replace(/src=(["']?)\/html-dfn\.js\1/g, `src=$1${dfnSrc}$1`);
+                content = content.replace(/<script[^>]*\bsrc=\/link-fixup\.js\b[^>]*><\/script>/g, "");
                 await fsp.writeFile(fullPath, content, "utf8");
             }));
         }


### PR DESCRIPTION
This addresses several shortcomings of 36833ab05c64fdb474aac02bdd6ac246a8ac6c2d:

1. The regular expression did not account for unquoted attribute values.
2. PR Preview can also generate files at a deeper directory, which requires a different path (or we'd have to duplicate the file, but this seems preferable).
3. The diff files require their own post-processing for a similar reason.
4. link-fixup.js is also a constant 404 and we might as well remove it while doing replacements.