### PR TITLE
Make HTML's html-dfn.js work, part 3

### DIFF
--- a/lib/models/file.js
+++ b/lib/models/file.js
@@ -11,7 +11,7 @@ const RemovedFileSpecDiff = SpecDiff.RemovedFileSpecDiff;
 
 // Rewrite html-dfn.js path (again) so it works for diff pages.
 const rewriteHtmlDfn = html =>
-    html.replace(/src="html-dfn\.js"/g, 'src="../html-dfn.js"');
+    html.replace(/src=(["']?)\/?html-dfn\.js\1/g, 'src=$1../html-dfn.js$1');
 
 
 class File {

--- a/lib/wattsi-client.js
+++ b/lib/wattsi-client.js
@@ -223,10 +223,10 @@ class WattsiClient {
     getFilenames() {
         return this.fetch()
             .then(_ => this.unzip())
-            .then(_ => this.rewriteMultipageFiles())
-            .then(_ => this.fetchHtmlDfn())
             .then(_ => this.diff())
-            .then(_ => this.getUnchangedFilenames());
+            .then(_ => this.getUnchangedFilenames())
+            .then(_ => this.rewriteMultipageFiles())
+            .then(_ => this.fetchHtmlDfn());
     }
 
     // Rewrite `src=/html-dfn.js` to a relative path so it works on PR Preview and drop link-fixup.js.


### PR DESCRIPTION
Unfortunately even with a698ca22b30eac161f1f9017263e6f13df218edd applied there were still some issues:

1. By rewriting before diffing, all pages would always be noted as changed. Changing the ordering should improve the UI.
2. The regular expression for the diff view wasn't correctly accounting for the earlier regular expression after all. Accept slightly more spellings to make it more robust against subtle variants.