### PR TITLE
[Editorial] Remove obsolete 'force' references

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,14 +107,14 @@ and the `owner`, `repo`, `branch`, `sha`, `short_sha` and `url` of the branch be
 ```
 
 Here's a fairly involved config file example the URL standard could use
-to produce [this snapshot](https://www.w3.org/publications/spec-generator/?type=bikeshed-spec&output=html&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fcsswg-drafts%2Fb636446f7636646695b7b3b799f2a0f14a18701d%2Fcompositing-1%2FOverview.bs&force=1&md-status=LS-COMMIT&md-h1=URL%20%3Csmall%3E(%3Ca%20href%3D%22https%3A%2F%2Fgithub.com%2Fwhatwg%2Furl%2Fpull%2F234%22%3EPR%20%23234%3C%2Fa%3E)%3C%2Fsmall%3E&md-warning=Commit%20b46bf40%20https%3A%2F%2Fgithub.com%2Fwatilde%2Furl%2Fcommit%2Fb46bf404569eece5597067e89749620faf0ea320%20replaced%20by%20https%3A%2F%2Furl.spec.whatwg.org%2F&md-title=URL%20Standard%20(Pull%20Request%20Snapshot%20%23234)&md-Text-Macro=SNAPSHOT-LINK%20%3Ca%20href%3D%22https%3A%2F%2Furl.spec.whatwg.org%2F%22%20id%3D%22commit-snapshot-link%22%3EGo%20to%20the%20living%20standard%3C%2Fa%3E).
+to produce [this snapshot](https://www.w3.org/publications/spec-generator/?type=bikeshed-spec&output=html&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fcsswg-drafts%2Fb636446f7636646695b7b3b799f2a0f14a18701d%2Fcompositing-1%2FOverview.bs&die-on=nothing&md-status=LS-COMMIT&md-h1=URL%20%3Csmall%3E(%3Ca%20href%3D%22https%3A%2F%2Fgithub.com%2Fwhatwg%2Furl%2Fpull%2F234%22%3EPR%20%23234%3C%2Fa%3E)%3C%2Fsmall%3E&md-warning=Commit%20b46bf40%20https%3A%2F%2Fgithub.com%2Fwatilde%2Furl%2Fcommit%2Fb46bf404569eece5597067e89749620faf0ea320%20replaced%20by%20https%3A%2F%2Furl.spec.whatwg.org%2F&md-title=URL%20Standard%20(Pull%20Request%20Snapshot%20%23234)&md-Text-Macro=SNAPSHOT-LINK%20%3Ca%20href%3D%22https%3A%2F%2Furl.spec.whatwg.org%2F%22%20id%3D%22commit-snapshot-link%22%3EGo%20to%20the%20living%20standard%3C%2Fa%3E).
 
 ```json
 {
     "src_file": "url.bs",
     "type": "bikeshed",
     "params": {
-        "force": 1,
+        "die-on": "nothing",
         "md-status": "LS-COMMIT",
         "md-h1": "URL <small>(<a href=\"{{ pull_request.html_url }}\">PR #{{ pull_request.number }}</a>)</small>",
         "md-warning": "Commit {{ short_sha }} {{ pull_request.head.repo.html_url }}/commit/{{ sha }} replaced by {{ config.ls_url }}",


### PR DESCRIPTION
This CL switches the `force=1` usage in the main README file to `die-on=nothing`

Now that spec-generator uses the `w3.org/publications/spec-generator` service, the `force` parameter is obsolete. According to the [documentation](https://github.com/w3c/spec-generator/wiki/Migrating-Bikeshed-HTTP-API-usage-to-spec%E2%80%90generator). It should be replaced by `die-on=nothing`.