### PR TITLE
Make tests use 'die-on' instead of 'force'

### DIFF
--- a/test/models/branch.js
+++ b/test/models/branch.js
@@ -201,12 +201,12 @@ suite("Branch model", function() {
             src_file: "index.bs",
             type: "bikeshed",
             params: {
-                "force": 1
+                "die-on": "nothing"
             }
         };
         assert.deepEqual(h.getUrl(h.urlOptions()), {
             method: "POST",
-            url: BIKESHED_URL + "index.bs&force=1"
+            url: BIKESHED_URL + "index.bs&die-on=nothing"
         });
     });
 
@@ -232,7 +232,7 @@ suite("Branch model", function() {
             src_file: "index.bs",
             type: "bikeshed",
             params: {
-                "force": 1
+                "die-on": "nothing"
             }
         }
         h.pr.config = config;


### PR DESCRIPTION
This PR switches the `force=1` usage to `die-on=nothing` in test\models\branch.js

After https://github.com/tobie/pr-preview/pull/172 was merged some `force=1` usages were missed in the test files. Since `force=1` is ignored by the new backend, these tests may have lost coverage. According to the [documentation](https://github.com/w3c/spec-generator/wiki/Migrating-Bikeshed-HTTP-API-usage-to-spec%E2%80%90generator). It should be replaced by `die-on=nothing`.